### PR TITLE
use JSON::PP rather than JSON module

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -38,7 +38,7 @@ my %args = (
     },
 
     test_requires => {
-        'JSON' => '2',
+        'JSON::PP' => '2',
         'Test::More' => '0.98',
     },
 

--- a/META.json
+++ b/META.json
@@ -51,7 +51,7 @@
       },
       "test" : {
          "requires" : {
-            "JSON" : "2",
+            "JSON::PP" : "2",
             "Test::More" : "0.98"
          }
       }

--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,6 @@ suggests 'WWW::Form::UrlEncoded::XS', '0.19';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
-    requires 'JSON', 2;
+    requires 'JSON::PP', 2;
 };
 

--- a/t/01_parse.t
+++ b/t/01_parse.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use WWW::Form::UrlEncoded qw/parse_urlencoded parse_urlencoded_arrayref/;
-use JSON;
+use JSON::PP;
 
 is_deeply([parse_urlencoded(undef)], []);
 is_deeply(parse_urlencoded_arrayref(undef), []);
@@ -13,9 +13,9 @@ while (<DATA>) {
     my ($s,$t) = split /\s+=>\s/, $_,2;
     $s =~ s/'//g;
     my @param = parse_urlencoded($s);
-    is JSON::encode_json(\@param), $t, $s;
+    is JSON::PP::encode_json(\@param), $t, $s;
     my $param = parse_urlencoded_arrayref($s);
-    is JSON::encode_json($param), $t, $s;
+    is JSON::PP::encode_json($param), $t, $s;
 }
 
 done_testing();

--- a/t/02_parse_pp.t
+++ b/t/02_parse_pp.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use WWW::Form::UrlEncoded::PP qw/parse_urlencoded parse_urlencoded_arrayref/;
-use JSON;
+use JSON::PP;
 
 is_deeply([parse_urlencoded(undef)], []);
 is_deeply(parse_urlencoded_arrayref(undef), []);
@@ -13,9 +13,9 @@ while (<DATA>) {
     my ($s,$t) = split /\s+=>\s/, $_,2;
     $s =~ s/'//g;
     my @param = parse_urlencoded($s);
-    is JSON::encode_json(\@param), $t, $s;
+    is JSON::PP::encode_json(\@param), $t, $s;
     my $param = parse_urlencoded_arrayref($s);
-    is JSON::encode_json($param), $t, $s;
+    is JSON::PP::encode_json($param), $t, $s;
 }
 
 done_testing();

--- a/t/03_build.t
+++ b/t/03_build.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use WWW::Form::UrlEncoded qw/build_urlencoded build_urlencoded_utf8/;
-use JSON;
+use JSON::PP;
 
 my @data = (
     ['a'=>'b'] => 'a=b',
@@ -29,7 +29,7 @@ my @data = (
 while ( @data ) {
     my $data = shift @data;
     my $test = shift @data;
-    is( build_urlencoded(@$data), $test, JSON::encode_json($data));
+    is( build_urlencoded(@$data), $test, JSON::PP::encode_json($data));
 }
 
 is( build_urlencoded([ foo => "\xE5", bar => "\x{263A}" ]), 'foo=%E5&bar=%E2%98%BA'); 

--- a/t/04_build_pp.t
+++ b/t/04_build_pp.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use WWW::Form::UrlEncoded::PP qw/build_urlencoded build_urlencoded_utf8/;
-use JSON;
+use JSON::PP;
 
 my @data = (
     ['a'=>'b'] => 'a=b',
@@ -29,7 +29,7 @@ my @data = (
 while ( @data ) {
     my $data = shift @data;
     my $test = shift @data;
-    is( build_urlencoded(@$data), $test, JSON::encode_json($data));
+    is( build_urlencoded(@$data), $test, JSON::PP::encode_json($data));
 }
 
 is( build_urlencoded([ foo => "\xE5", bar => "\x{263A}" ]), 'foo=%E5&bar=%E2%98%BA'); 

--- a/t/05_parse_arrayref.t
+++ b/t/05_parse_arrayref.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use WWW::Form::UrlEncoded qw/parse_urlencoded_arrayref/;
-use JSON;
+use JSON::PP;
 
 while (<DATA>) {
     chomp;
@@ -10,7 +10,7 @@ while (<DATA>) {
     my ($s,$t) = split /\s+=>\s/, $_,2;
     $s =~ s/'//g;
     my $param = parse_urlencoded_arrayref($s);
-    is JSON::encode_json($param), $t, $s;
+    is JSON::PP::encode_json($param), $t, $s;
 }
 
 done_testing();

--- a/t/06_parse_arrayref_pp.t
+++ b/t/06_parse_arrayref_pp.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use WWW::Form::UrlEncoded::PP qw/parse_urlencoded_arrayref/;
-use JSON;
+use JSON::PP;
 
 while (<DATA>) {
     chomp;
@@ -10,7 +10,7 @@ while (<DATA>) {
     my ($s,$t) = split /\s+=>\s/, $_,2;
     $s =~ s/'//g;
     my $param = parse_urlencoded_arrayref($s);
-    is JSON::encode_json($param), $t, $s;
+    is JSON::PP::encode_json($param), $t, $s;
 }
 
 done_testing();


### PR DESCRIPTION
The JSON module is only used in tests, so speed is not particularly
important.  JSON::PP can be used instead of JSON to avoid the extra
non-core dependency.