### PR TITLE
Allow third party distributors to make the module arch-independent

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -9,6 +9,9 @@ use File::Path;
 sub ACTION_code {
     my $self = shift;
     $self->SUPER::ACTION_code();
+
+    return if $ENV{BREAK_BACKWARD_COMPAT};
+
     my $archdir = File::Spec->catdir($self->blib,'arch','auto','WWW','Form','UrlEncoded','XS');
     File::Path::mkpath($archdir, 0, oct(777)) unless -d $archdir;
     my $keep_arch = File::Spec->catfile($archdir,'.keep');


### PR DESCRIPTION
Hi,

Currently, the module installs as an arch-dependent one, while containing only PP code. It's fine, if the module is obtained via cpan directly, but it causes packaging lists issues for third party distributors (OS vendors mostly) against the XS version of this module.

[Debian zaps the keepfile](https://sources.debian.org/patches/libwww-form-urlencoded-perl/0.23-2/arch_all.patch/), and as @wenheping asked to import this module to OpenBSD ports, i [did the same](https://marc.info/?l=openbsd-ports&m=155845480616360&w=2).

I'm proposing here a compromise, by defining a `BREAK_BACKWARD_COMPAT` environment variable, that can be used to  make the module arch-independent.